### PR TITLE
remove yarn.resourcemanager.hostname explicit set

### DIFF
--- a/conf/yarn-site.xml
+++ b/conf/yarn-site.xml
@@ -26,8 +26,4 @@ under the License.
     <name>yarn.nodemanager.vmem-pmem-ratio</name>
     <value>10</value>
   </property>
-  <property>
-    <name>yarn.resourcemanager.hostname</name>
-    <value>127.0.0.1</value>
-  </property>
 </configuration>


### PR DESCRIPTION
I couldn't connect to the YARN UI on port 8088. I am not sure why it is specifically being set. Maybe i am missing something.

```
netstat -anp | grep 8088

tcp6       0      0 127.0.0.1:8088          :::*                    LISTEN      5378/java
```

After removing explicit set of yarn.resourcemanager.hostname I was able to access the YARN UI.

```
netstat -anp | grep 8088

tcp6       0      0 :::8088                 :::*                    LISTEN      8725/java
```
