### PR TITLE
Update grid script to reference correct kafka version

### DIFF
--- a/bin/grid
+++ b/bin/grid
@@ -90,7 +90,7 @@ install_yarn() {
 
 install_kafka() {
   mkdir -p "$DEPLOY_ROOT_DIR"
-  install kafka $DOWNLOAD_KAFKA kafka_2.10-0.8.1.1
+  install kafka $DOWNLOAD_KAFKA kafka_2.10-0.8.2.0
   # have to use SIGTERM since nohup on appears to ignore SIGINT
   # and Kafka switched to SIGINT in KAFKA-1031.
   sed -i.bak 's/SIGINT/SIGTERM/g' $DEPLOY_ROOT_DIR/kafka/bin/kafka-server-stop.sh


### PR DESCRIPTION
Currently, the grid install kafka script fails because the final portion of the script looks for the previous version of kafka.