### PR TITLE
Maven profile for the CDH compatible build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,38 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-annotations</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
-      <version>2.6.1</version>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-api</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-common</artifactId>
+      <version>${hadoop.version}</version>
     </dependency>
   </dependencies>
 
@@ -114,6 +144,7 @@ under the License.
     <!-- maven specific properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <samza.version>0.10.0-SNAPSHOT</samza.version>
+    <hadoop.version>2.6.1</hadoop.version>
   </properties>
 
   <developers>
@@ -156,6 +187,11 @@ under the License.
       <id>scala-tools.org</id>
       <name>Scala-tools Maven2 Repository</name>
       <url>https://oss.sonatype.org/content/groups/scala-tools</url>
+    </repository>
+    <repository>
+      <id>cloudera-repos</id>
+      <name>Cloudera Repos</name>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
     </repository>
   </repositories>
 
@@ -238,4 +274,20 @@ under the License.
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- CDH compatible build: mvn clean package -Denv=cdh5.4.0 -->
+    <profile>
+      <id>cdh5.4.0</id>
+      <activation>
+        <property>
+          <name>env</name>
+          <value>cdh5.4.0</value>
+        </property>
+      </activation>
+      <properties>
+        <hadoop.version>2.6.0-cdh5.4.0</hadoop.version>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Hello-samza 0.10.0 doesn't work on CDH (tested on CDH5.4.0) due to incompatible Hadoop jars, so this patch adds an optional Maven profile that builds hello-samza where generic Hadoop jars replaced with Cloudera Hadoop jars. 
Just run: mvn clean package -Denv=cdh5.4.0
If profile not specified, hello-samza built with default Hadoop dependencies.