### PR TITLE
Increase service wait timeout

### DIFF
--- a/bin/grid
+++ b/bin/grid
@@ -39,7 +39,7 @@ DOWNLOAD_KAFKA=https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.
 DOWNLOAD_YARN=https://archive.apache.org/dist/hadoop/common/hadoop-2.6.1/hadoop-2.6.1.tar.gz
 DOWNLOAD_ZOOKEEPER=http://archive.apache.org/dist/zookeeper/zookeeper-3.4.3/zookeeper-3.4.3.tar.gz
 
-SERVICE_WAIT_TIMEOUT_SEC=20
+SERVICE_WAIT_TIMEOUT_SEC=40
 ZOOKEEPER_PORT=2181
 RESOURCEMANAGER_PORT=8032
 NODEMANAGER_PORT=8042


### PR DESCRIPTION
The existing timeout of 20 seconds seems unreasonably low, and results in startup errors on low to mid-end systems.