### PR TITLE
Update Cookbook examples

### DIFF
--- a/src/main/config/filter-example.properties
+++ b/src/main/config/filter-example.properties
@@ -17,11 +17,12 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=stock-price-table-joiner
-job.container.count=1
+job.name=pageview-filter
+job.container.count=2
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.StockPriceTableJoiner
+app.class=samza.examples.cookbook.FilterExample
+task.window.ms=2000

--- a/src/main/config/join-example.properties
+++ b/src/main/config/join-example.properties
@@ -17,12 +17,12 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=pageview-filter
+job.name=pageview-adclick-joiner
 job.container.count=2
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.PageViewFilterApp
+app.class=samza.examples.cookbook.JoinExample
 task.window.ms=2000

--- a/src/main/config/remote-table-join-example.properties
+++ b/src/main/config/remote-table-join-example.properties
@@ -17,12 +17,11 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=pageview-sessionizer
-job.container.count=2
+job.name=stock-price-table-joiner
+job.container.count=1
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.PageViewSessionizerApp
-task.window.ms=2000
+app.class=samza.examples.cookbook.RemoteTableJoinExample

--- a/src/main/config/session-window-example.properties
+++ b/src/main/config/session-window-example.properties
@@ -17,12 +17,12 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=tumbling-pageview-counter
+job.name=pageview-sessionizer
 job.container.count=2
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.TumblingPageViewCounterApp
+app.class=samza.examples.cookbook.SessionWindowExample
 task.window.ms=2000

--- a/src/main/config/stream-table-join-example.properties
+++ b/src/main/config/stream-table-join-example.properties
@@ -17,12 +17,11 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=pageview-adclick-joiner
+job.name=pageview-profile-table-joiner
 job.container.count=2
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.PageViewAdClickJoiner
-task.window.ms=2000
+app.class=samza.examples.cookbook.StreamTableJoinExample

--- a/src/main/config/tumbling-window-example.properties
+++ b/src/main/config/tumbling-window-example.properties
@@ -17,11 +17,12 @@
 
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
-job.name=pageview-profile-table-joiner
+job.name=tumbling-pageview-counter
 job.container.count=2
 
 # YARN
 yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
 
 # Task
-app.class=samza.examples.cookbook.PageViewProfileTableJoiner
+app.class=samza.examples.cookbook.TumblingWindowExample
+task.window.ms=2000

--- a/src/main/java/samza/examples/cookbook/FilterExample.java
+++ b/src/main/java/samza/examples/cookbook/FilterExample.java
@@ -38,9 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * In this example, we demonstrate re-partitioning a stream of page views and filtering out some bad events in the stream.
+ * In this example, we demonstrate filtering out some bad events in the stream.
  *
- * <p>Concepts covered: Using stateless operators on a stream, Re-partitioning a stream.
+ * <p>Concepts covered: Using stateless operators on a stream.
  *
  * To run the below example:
  *
@@ -51,7 +51,7 @@ import java.util.Map;
  *   </li>
  *   <li>
  *     Run the application using the run-app.sh script <br/>
- *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/pageview-filter.properties
+ *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/filter-example.properties
  *   </li>
  *   <li>
  *     Produce some messages to the "pageview-filter-input" topic <br/>
@@ -66,7 +66,7 @@ import java.util.Map;
  *   </li>
  * </ol>
  */
-public class PageViewFilterApp implements StreamApplication {
+public class FilterExample implements StreamApplication {
   private static final String KAFKA_SYSTEM_NAME = "kafka";
   private static final List<String> KAFKA_CONSUMER_ZK_CONNECT = ImmutableList.of("localhost:2181");
   private static final List<String> KAFKA_PRODUCER_BOOTSTRAP_SERVERS = ImmutableList.of("localhost:9092");
@@ -95,7 +95,6 @@ public class PageViewFilterApp implements StreamApplication {
     OutputStream<KV<String, PageView>> filteredPageViews = appDescriptor.getOutputStream(outputDescriptor);
 
     pageViews
-        .partitionBy(kv -> kv.value.userId, kv -> kv.value, "pageview")
         .filter(kv -> !INVALID_USER_ID.equals(kv.value.userId))
         .sendTo(filteredPageViews);
   }

--- a/src/main/java/samza/examples/cookbook/JoinExample.java
+++ b/src/main/java/samza/examples/cookbook/JoinExample.java
@@ -18,6 +18,7 @@
  */
 package samza.examples.cookbook;
 
+import java.io.Serializable;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.application.StreamApplicationDescriptor;
 import org.apache.samza.operators.KV;
@@ -56,7 +57,7 @@ import java.util.Map;
  *   </li>
  *   <li>
  *     Run the application using the run-app.sh script <br/>
- *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/pageview-adclick-joiner.properties
+ *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/join-example.properties
  *   </li>
  *   <li>
  *     Produce some messages to the "pageview-join-input" topic <br/>
@@ -77,7 +78,7 @@ import java.util.Map;
  * </ol>
  *
  */
-public class PageViewAdClickJoiner implements StreamApplication {
+public class JoinExample implements StreamApplication, Serializable {
   private static final String KAFKA_SYSTEM_NAME = "kafka";
   private static final List<String> KAFKA_CONSUMER_ZK_CONNECT = ImmutableList.of("localhost:2181");
   private static final List<String> KAFKA_PRODUCER_BOOTSTRAP_SERVERS = ImmutableList.of("localhost:9092");

--- a/src/main/java/samza/examples/cookbook/RemoteTableJoinExample.java
+++ b/src/main/java/samza/examples/cookbook/RemoteTableJoinExample.java
@@ -73,7 +73,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  *   </li>
  *   <li>
  *     Run the application using the run-app.sh script <br/>
- *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/stock-price-table-joiner.properties
+ *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/remote-table-join-example.properties
  *   </li>
  *   <li>
  *     Consume messages from the output topic <br/>
@@ -94,7 +94,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * </ol>
  *
  */
-public class StockPriceTableJoiner implements StreamApplication {
+public class RemoteTableJoinExample implements StreamApplication {
   private static final String KAFKA_SYSTEM_NAME = "kafka";
   private static final List<String> KAFKA_CONSUMER_ZK_CONNECT = ImmutableList.of("localhost:2181");
   private static final List<String> KAFKA_PRODUCER_BOOTSTRAP_SERVERS = ImmutableList.of("localhost:9092");

--- a/src/main/java/samza/examples/cookbook/StreamTableJoinExample.java
+++ b/src/main/java/samza/examples/cookbook/StreamTableJoinExample.java
@@ -59,7 +59,7 @@ import java.util.Map;
  *   </li>
  *   <li>
  *     Run the application using the run-app.sh script <br/>
- *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/pageview-profile-table-joiner.properties
+ *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/stream-table-join-example.properties
  *   </li>
  *   <li>
  *     Produce some messages to the "profile-table-input" topic with the same userId <br/>
@@ -80,7 +80,7 @@ import java.util.Map;
  * </ol>
  *
  */
-public class PageViewProfileTableJoiner implements StreamApplication {
+public class StreamTableJoinExample implements StreamApplication {
   private static final String KAFKA_SYSTEM_NAME = "kafka";
   private static final List<String> KAFKA_CONSUMER_ZK_CONNECT = ImmutableList.of("localhost:2181");
   private static final List<String> KAFKA_PRODUCER_BOOTSTRAP_SERVERS = ImmutableList.of("localhost:9092");
@@ -128,7 +128,7 @@ public class PageViewProfileTableJoiner implements StreamApplication {
         .sendTo(joinResultStream);
   }
 
-  private class JoinFn implements StreamTableJoinFunction<String, KV<String, PageView>, KV<String, Profile>, EnrichedPageView> {
+  private static class JoinFn implements StreamTableJoinFunction<String, KV<String, PageView>, KV<String, Profile>, EnrichedPageView> {
     @Override
     public EnrichedPageView apply(KV<String, PageView> message, KV<String, Profile> record) {
       return record == null ? null :


### PR DESCRIPTION
Updating cookbook examples with latest api. I verified all the applications except table examples. Found a bug (https://github.com/apache/samza/pull/684) in metadatastore with Table example. Once the fix is in, need to verify the table examples again.

Also change the name of the examples as we discussed before.