### PR TITLE
Kafka Download URL correction and version bump for ZK & Kafka

### DIFF
--- a/bin/grid
+++ b/bin/grid
@@ -35,9 +35,9 @@ DOWNLOAD_CACHE_DIR=$HOME/.samza/download
 COMMAND=$1
 SYSTEM=$2
 
-DOWNLOAD_KAFKA=http://www.us.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz
+DOWNLOAD_KAFKA=https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz
 DOWNLOAD_YARN=https://archive.apache.org/dist/hadoop/common/hadoop-2.6.1/hadoop-2.6.1.tar.gz
-DOWNLOAD_ZOOKEEPER=http://archive.apache.org/dist/zookeeper/zookeeper-3.4.3/zookeeper-3.4.3.tar.gz
+DOWNLOAD_ZOOKEEPER=https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz
 
 SERVICE_WAIT_TIMEOUT_SEC=20
 ZOOKEEPER_PORT=2181
@@ -96,7 +96,7 @@ install_samza() {
 
 install_zookeeper() {
   mkdir -p "$DEPLOY_ROOT_DIR"
-  install zookeeper $DOWNLOAD_ZOOKEEPER zookeeper-3.4.3
+  install zookeeper $DOWNLOAD_ZOOKEEPER zookeeper-3.4.14
   cp "$DEPLOY_ROOT_DIR/zookeeper/conf/zoo_sample.cfg" "$DEPLOY_ROOT_DIR/zookeeper/conf/zoo.cfg"
 }
 
@@ -112,7 +112,7 @@ install_yarn() {
 
 install_kafka() {
   mkdir -p "$DEPLOY_ROOT_DIR"
-  install kafka $DOWNLOAD_KAFKA kafka_2.11-0.10.2.1
+  install kafka $DOWNLOAD_KAFKA kafka_2.11-2.1.1
   # have to use SIGTERM since nohup on appears to ignore SIGINT
   # and Kafka switched to SIGINT in KAFKA-1031.
   sed -i.bak 's/SIGINT/SIGTERM/g' $DEPLOY_ROOT_DIR/kafka/bin/kafka-server-stop.sh


### PR DESCRIPTION
The download path to the Kafka binary was incorrect.  In addition to correcting the url path, I changed the URIs to use https and bumped the zookeeper & kafka versions.

Changes were tested by running `./bin/grid bootstrap`.