### PR TITLE
SAMZA-2437: Sample for producing to Azure Blob Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,26 @@ under the License.
       <artifactId>guava</artifactId>
       <version>23.0</version>
     </dependency>
+    <!-- Jackson Dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+
+    <dependency>
+
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -206,26 +206,6 @@ under the License.
       <artifactId>guava</artifactId>
       <version>23.0</version>
     </dependency>
-    <!-- Jackson Dependencies -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.10.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.0</version>
-    </dependency>
-
-    <dependency>
-
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.10.0</version>
-    </dependency>
-
   </dependencies>
 
   <properties>

--- a/src/main/config/azure-blob-application.properties
+++ b/src/main/config/azure-blob-application.properties
@@ -15,6 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Instructions to run this samza job are given in {@link samza.examples.azure.AzureBlobApplication}
+
+# "azure-blob-container" creates an Azure Container (if it doesnt already exist) in Azure Storage Account.
+# For valid container names follow guidance in https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
+
 # Job
 job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
 job.name=azure-blob
@@ -26,12 +31,9 @@ yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-
 app.class=samza.examples.azure.AzureBlobApplication
 
 #Azure blob essential configs
-systems.oss-testcontainer.samza.factory=org.apache.samza.system.azureblob.AzureBlobSystemFactory
-sensitive.systems.oss-testcontainer.azureblob.account.name=your-azure-storage-account-name
-sensitive.systems.oss-testcontainer.azureblob.account.key=your-azure-storage-account-key
+systems.azure-blob-container.samza.factory=org.apache.samza.system.azureblob.AzureBlobSystemFactory
+sensitive.systems.azure-blob-container.azureblob.account.name=your-azure-storage-account-name
+sensitive.systems.azure-blob-container.azureblob.account.key=your-azure-storage-account-key
 
 #Azure blob config - to created a blob per 2 input kafka messages
-systems.oss-testcontainer.azureblob.maxMessagesPerBlob=2
-
-# Add configuration to disable checkpointing for this job once it is available in the Coordinator Stream model
-# See https://issues.apache.org/jira/browse/SAMZA-465?focusedCommentId=14533346&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14533346 for more details
+systems.azure-blob-container.azureblob.maxMessagesPerBlob=2

--- a/src/main/config/azure-blob-application.properties
+++ b/src/main/config/azure-blob-application.properties
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Job
+job.factory.class=org.apache.samza.job.yarn.YarnJobFactory
+job.name=azure-blob
+
+# YARN package path
+yarn.package.path=file://${basedir}/target/${project.artifactId}-${pom.version}-dist.tar.gz
+
+# StreamApplication class
+app.class=samza.examples.azure.AzureBlobApplication
+
+#Azure blob essential configs
+systems.oss-testcontainer.samza.factory=org.apache.samza.system.azureblob.AzureBlobSystemFactory
+sensitive.systems.oss-testcontainer.azureblob.account.name=your-azure-storage-account-name
+sensitive.systems.oss-testcontainer.azureblob.account.key=your-azure-storage-account-key
+
+#Azure blob config - to created a blob per 2 input kafka messages
+systems.oss-testcontainer.azureblob.maxMessagesPerBlob=2
+
+# Add configuration to disable checkpointing for this job once it is available in the Coordinator Stream model
+# See https://issues.apache.org/jira/browse/SAMZA-465?focusedCommentId=14533346&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14533346 for more details

--- a/src/main/java/samza/examples/azure/AzureBlobApplication.java
+++ b/src/main/java/samza/examples/azure/AzureBlobApplication.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package samza.examples.azure;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.samza.application.StreamApplication;
+import org.apache.samza.application.descriptors.StreamApplicationDescriptor;
+import org.apache.samza.operators.MessageStream;
+import org.apache.samza.operators.OutputStream;
+import org.apache.samza.serializers.JsonSerdeV2;
+import org.apache.samza.serializers.NoOpSerde;
+import org.apache.samza.system.descriptors.GenericOutputDescriptor;
+import org.apache.samza.system.descriptors.GenericSystemDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
+import samza.examples.azure.data.PageViewAvroRecord;
+import samza.examples.cookbook.data.PageView;
+
+/**
+ * In this example, we demonstrate sending blobs to Azure Blob Storage.
+ * This Samza job reads from Kafka topic "page-view-azure-blob-input" and produces blobs to Azure-Container "oss-testcontainer" in your Azure Storage account.
+ *
+ * Currently, Samza supports sending Avro files are blobs.
+ * Hence the incoming messages into the Samza job have to be converted to an Avro record.
+ * For this job, we use input message as {@link samza.examples.cookbook.data.PageView} and
+ * covert it to an Avro record defined as {@link samza.examples.azure.data.PageViewAvroRecord}.
+ *
+ * To run the below example:
+ *
+ * <ol>
+ *   <li>
+ *     Replace your-azure-storage-account-name and your-azure-storage-account-key with details of your Azure Storage Account.
+ *   </li>
+ *   <li>
+ *     Ensure that the topic "page-view-azure-blob-input" is created  <br/>
+ *     ./deploy/kafka/bin/kafka-topics.sh  --zookeeper localhost:2181 --create --topic page-view-azure-blob-input --partitions 1 --replication-factor 1
+ *   </li>
+ *   <li>
+ *     Run the application using the run-app.sh script <br/>
+ *     ./deploy/samza/bin/run-app.sh --config-factory=org.apache.samza.config.factories.PropertiesConfigFactory --config-path=file://$PWD/deploy/samza/config/azure-blob-application.properties
+ *   </li>
+ *   <li>
+ *     Produce some messages to the "page-view-azure-blob-input" topic <br/>
+ *     ./deploy/kafka/bin/kafka-console-producer.sh --topic page-view-azure-blob-input --broker-list localhost:9092 <br/>
+ *     {"userId": "user1", "country": "india", "pageId":"google.com"} <br/>
+ *     {"userId": "user2", "country": "france", "pageId":"facebook.com"} <br/>
+ *     {"userId": "user3", "country": "china", "pageId":"yahoo.com"} <br/>
+ *     {"userId": "user4", "country": "italy", "pageId":"linkedin.com"} <br/>
+ *     {"userId": "user5", "country": "germany", "pageId":"amazon.com"} <br/>
+ *     {"userId": "user6", "country": "denmark", "pageId":"apple.com"} <br/>
+ *   </li>
+ *   <li>
+ *    Seeing Output:
+ *    <ol>
+ *      <li>
+ *       See blobs in your Azure portal at https://<azure-storage-account-name>.blob.core.windows.net/oss-testcontainer/PageViewEventStream/<time-stamp>.avro
+ *      </li>
+ *      <li>
+ *       system-name "oss-testcontainer" in configs and code below maps to Azure-Container in Azure Storage account.
+ *      </li>
+ *      <li>
+ *       <time-stamp> is of the format yyyy/MM/dd/HH/mm-ss-randomString.avro. Hence navigate through the virtual folders on the portal to see your blobs.
+ *      </li>
+ *      <li>
+ *       Due to network calls, allow a few minutes for blobs to appear on the portal.
+ *      </li>
+ *      <li>
+ *       Config "maxMessagesPerBlob=2" ensures that a blob is created per 2 input messages. Adjust input or config accordingly.
+ *      </li>
+ *    </ol>
+ *   </li>
+ * </ol>
+ */
+public class AzureBlobApplication implements StreamApplication {
+  private static final List<String> KAFKA_CONSUMER_ZK_CONNECT = ImmutableList.of("localhost:2181");
+  private static final List<String> KAFKA_PRODUCER_BOOTSTRAP_SERVERS = ImmutableList.of("localhost:9092");
+  private static final Map<String, String> KAFKA_DEFAULT_STREAM_CONFIGS = ImmutableMap.of("replication.factor", "1");
+  private static final String INPUT_PAGEVIEW_STREAM_ID = "page-view-azure-blob-input";
+  private static final String OUTPUT_SYSTEM = "oss-testcontainer";
+  private static final String OUTPUT_STREAM = "PageViewEventStream";
+
+  @Override
+  public void describe(StreamApplicationDescriptor appDescriptor) {
+    // Define a system descriptor for Kafka
+    KafkaSystemDescriptor kafkaSystemDescriptor =
+        new KafkaSystemDescriptor("kafka").withConsumerZkConnect(KAFKA_CONSUMER_ZK_CONNECT)
+            .withProducerBootstrapServers(KAFKA_PRODUCER_BOOTSTRAP_SERVERS)
+            .withDefaultStreamConfigs(KAFKA_DEFAULT_STREAM_CONFIGS);
+
+    KafkaInputDescriptor<PageView> pageViewInputDescriptor =
+        kafkaSystemDescriptor.getInputDescriptor(INPUT_PAGEVIEW_STREAM_ID, new JsonSerdeV2<>(PageView.class));
+
+    // Define a system descriptor for Azure Blob Storage
+    GenericSystemDescriptor azureBlobSystemDescriptor =
+        new GenericSystemDescriptor(OUTPUT_SYSTEM, "org.apache.samza.system.azureblob.AzureBlobSystemFactory");
+
+    GenericOutputDescriptor<PageViewAvroRecord> azureBlobOuputDescriptor =
+        azureBlobSystemDescriptor.getOutputDescriptor(OUTPUT_STREAM, new NoOpSerde<>());
+
+    // Set Kafka as the default system for the job
+    appDescriptor.withDefaultSystem(kafkaSystemDescriptor);
+
+    // Define the input and output streams with descriptors
+    MessageStream<PageView> pageViewInput = appDescriptor.getInputStream(pageViewInputDescriptor);
+    OutputStream<PageViewAvroRecord> pageViewAvroRecordOutputStream = appDescriptor.getOutputStream(azureBlobOuputDescriptor);
+
+    // Define the execution flow with the high-level API
+    pageViewInput
+        .map((message) -> {
+          System.out.println("Sending: ");
+          System.out.println("Received PageViewEvent with pageId: " + message.pageId);
+          return PageViewAvroRecord.buildPageViewRecord(message);
+        })
+        .sendTo(pageViewAvroRecordOutputStream);
+  }
+}

--- a/src/main/java/samza/examples/azure/data/PageViewAvroRecord.java
+++ b/src/main/java/samza/examples/azure/data/PageViewAvroRecord.java
@@ -15,9 +15,9 @@ public class PageViewAvroRecord extends org.apache.avro.specific.SpecificRecordB
 
   public static PageViewAvroRecord buildPageViewRecord(PageView pageView) {
     PageViewAvroRecord record = new PageViewAvroRecord();
-    record.put(0, pageView.userId);
-    record.put(1, pageView.country);
-    record.put(2, pageView.pageId);
+    record.userId = pageView.userId;
+    record.country = pageView.country;
+    record.pageId = pageView.pageId;
     return record;
   }
   public org.apache.avro.Schema getSchema() {

--- a/src/main/java/samza/examples/azure/data/PageViewAvroRecord.java
+++ b/src/main/java/samza/examples/azure/data/PageViewAvroRecord.java
@@ -1,0 +1,48 @@
+package samza.examples.azure.data;
+
+import java.io.Serializable;
+import org.apache.avro.AvroRuntimeException;
+import samza.examples.cookbook.data.PageView;
+
+public class PageViewAvroRecord extends org.apache.avro.specific.SpecificRecordBase
+    implements org.apache.avro.specific.SpecificRecord, Serializable {
+  public final org.apache.avro.Schema SCHEMA = org.apache.avro.Schema.parse(
+      "{\"type\":\"record\",\"name\":\"PageViewAvroRecord\",\"namespace\":\"org.apache.samza.examples.events\", \"fields\":[{\"name\": \"userId\", \"type\": \"string\"}, {\"name\": \"country\", \"type\": \"string\"}, {\"name\": \"pageId\", \"type\": \"string\"}]}");
+
+  private String userId;
+  private String country;
+  private String pageId;
+
+  public static PageViewAvroRecord buildPageViewRecord(PageView pageView) {
+    PageViewAvroRecord record = new PageViewAvroRecord();
+    record.put(0, pageView.userId);
+    record.put(1, pageView.country);
+    record.put(2, pageView.pageId);
+    return record;
+  }
+  public org.apache.avro.Schema getSchema() {
+    return SCHEMA;
+  }
+
+  public java.lang.Object get(int field) {
+    switch (field) {
+      case 0: return userId;
+      case 1: return country;
+      case 2: return pageId;
+      default: throw new AvroRuntimeException("bad index");
+    }
+  }
+
+  public void put(int field, Object value) {
+    switch (field) {
+      case 0:
+        userId = (String) value; break;
+      case 1:
+        country = (String) value; break;
+      case 2:
+        pageId = (String) value; break;
+      default:
+        throw new AvroRuntimeException("bad index");
+    }
+  }
+}


### PR DESCRIPTION
Feature: Sample Samza job related to SEP-26: Azure Blob System Producer

Changes: New high-level Yarn job "AzureBlobApplication" added to the samples

Tests: Sample job successfully produces blobs for configured Azure Storage Account. Confirmed on Azure portal.

Upgrade instructions: Backwards compatible change as its a completely new job and hence no upgrade needed.

Usage instructions: Add Azure Storage Account details to the configs of the Samza job. Step-by-step instructions to run the job are provided in the javadocs of the job.